### PR TITLE
Emu backend mdspan iia

### DIFF
--- a/core/src/CilkPlus/Kokkos_CilkEmu_Reduce.hpp
+++ b/core/src/CilkPlus/Kokkos_CilkEmu_Reduce.hpp
@@ -4,8 +4,10 @@
 
 #include <cilk/cilk.h>
 #include <cilk/reducer.h>
-#include <intrinsics.h>
-#include <pmanip.h>
+//Replace specific Emu headers with the tools header to allow x86 compilation
+#include <emu_c_utils/emu_c_utils.h>
+//#include <intrinsics.h>
+//#include <pmanip.h>
 
 namespace Kokkos {
 namespace Impl {

--- a/core/src/CilkPlus/Kokkos_CilkPlus_Range.hpp
+++ b/core/src/CilkPlus/Kokkos_CilkPlus_Range.hpp
@@ -8,7 +8,9 @@
 #endif
 #include <cilk/cilk.h>
 #include <memory.h>
-#include <pmanip.h>
+//Replace specific Emu headers with the tools header to allow x86 compilation
+#include <emu_c_utils/emu_c_utils.h>
+//#include <pmanip.h>
 
 //#define KOKKOS_CILK_USE_PARALLEL_FOR
 #define MAX_THREAD_COUNT 32

--- a/core/src/CilkPlus/Kokkos_CilkPlus_Task.hpp
+++ b/core/src/CilkPlus/Kokkos_CilkPlus_Task.hpp
@@ -320,7 +320,7 @@ public:
       0    /* thread local buffer */
     );
 
-    long * data_ref = mw_malloc1dlong(NODELETS());
+    long * data_ref = (long*)mw_malloc1dlong(NODELETS());
 
     int offset = 0;    
     for ( int i = 0; i < NODELETS(); i++ ) {

--- a/core/src/CilkPlus/Kokkos_EmuMemoryPool.hpp
+++ b/core/src/CilkPlus/Kokkos_EmuMemoryPool.hpp
@@ -335,7 +335,7 @@ public:
       const size_t alloc_size  = ( header_size +
                                  ( size_t(m_sb_count) << m_sb_size_lg2 ) ) * 
                                  Kokkos::Experimental::EmuReplicatedSpace::memory_zones();
-      m_sb_lock_array = mw_malloc1dlong(Kokkos::Experimental::EmuReplicatedSpace::memory_zones());
+      m_sb_lock_array = (long*)mw_malloc1dlong(Kokkos::Experimental::EmuReplicatedSpace::memory_zones());
       m_sb_state_array = (long**)memspace.allocate( alloc_size );
       
       //printf("%s memory pool allocated: %08x \n", memspace.name(), (unsigned long)m_sb_state_array);
@@ -671,7 +671,7 @@ public:
       ATOMIC_SWAP(&m_sb_lock_array[add_info], 0);
       
       if (p == nullptr) {
-		  printf("Cannot allocate memory pool data of size: %d \n", alloc_size);
+		  printf("Cannot allocate memory pool data of size: %lu \n", alloc_size);
 		  fflush(stdout);
 	  }
 

--- a/core/src/CilkPlus/Kokkos_EmuSpace.cpp
+++ b/core/src/CilkPlus/Kokkos_EmuSpace.cpp
@@ -58,15 +58,18 @@
 #include <Kokkos_EmuSpace.hpp>
 #include <impl/Kokkos_Error.hpp>
 
-#include <intrinsics.h>
+//Replace specific Emu headers with the tools header to allow x86 compilation
+#include <emu_c_utils/emu_c_utils.h>
+//#include <intrinsics.h>
 
-struct emu_pointer {
+/*struct emu_pointer {
     uint64_t view;
     uint64_t node_id;
     uint64_t nodelet_id;
     uint64_t nodelet_addr;
     uint64_t byte_offset;
 };
+*/
 
 extern "C"{
    struct emu_pointer
@@ -147,7 +150,7 @@ static long * ref_ptr = 0;
 
 static long * getRefPtr() {
    if ( ref_ptr == 0) {
-      ref_ptr = mw_malloc1dlong( NODELETS() );
+      ref_ptr = (long*)mw_malloc1dlong( NODELETS() );
    }
    return ref_ptr;
 }

--- a/core/src/CilkPlus/Kokkos_SimpleEmuTaskScheduler.hpp
+++ b/core/src/CilkPlus/Kokkos_SimpleEmuTaskScheduler.hpp
@@ -64,7 +64,9 @@
 #include <impl/Kokkos_TaskTeamMember.hpp>
 #include <impl/Kokkos_EBO.hpp>
 
-#include <intrinsics.h>
+//Replace specific Emu headers with the tools header to allow x86 compilation
+#include <emu_c_utils/emu_c_utils.h>
+//#include <intrinsics.h>
 
 namespace Kokkos {
 	

--- a/core/src/Kokkos_CilkPlus.hpp
+++ b/core/src/Kokkos_CilkPlus.hpp
@@ -145,7 +145,7 @@ public:
   /// method does not return until all dispatched functors on this
   /// device have completed.
   static void fence() {
-     cilk_sync;
+     //cilk_sync;
   }
 
   static void initialize( unsigned threads_count = 1 ,

--- a/core/src/Kokkos_EmuSpace.hpp
+++ b/core/src/Kokkos_EmuSpace.hpp
@@ -50,9 +50,11 @@
 #include <Kokkos_Core_fwd.hpp>
 #include <cilk/cilk.h>
 #include <memory.h>
-#include <intrinsics.h>
-#include <repl.h>
-#include <pmanip.h>
+//Replace specific Emu headers with the tools header to allow x86 compilation
+#include <emu_c_utils/emu_c_utils.h>
+//#include <intrinsics.h>
+//#include <repl.h>
+//#include <pmanip.h>
 #include <Kokkos_HostSpace.hpp>
 
 /*--------------------------------------------------------------------------*/

--- a/core/src/impl/Kokkos_Atomic_Compare_Exchange_Strong.hpp
+++ b/core/src/impl/Kokkos_Atomic_Compare_Exchange_Strong.hpp
@@ -54,7 +54,9 @@
 #endif
 
 #if defined(KOKKOS_ENABLE_EMU)
-#include <memoryweb/intrinsics.h>
+//Replace specific Emu headers with the tools header to allow x86 compilation
+#include <emu_c_utils/emu_c_utils.h>
+//#include <memoryweb/intrinsics.h>
 #include <mutex>
 #include <map>
 #endif

--- a/core/src/impl/Kokkos_Atomic_Exchange.hpp
+++ b/core/src/impl/Kokkos_Atomic_Exchange.hpp
@@ -54,7 +54,9 @@
 #endif
 
 #if defined(KOKKOS_ENABLE_EMU)
-#include <intrinsics.h>
+//Replace specific Emu headers with the tools header to allow x86 compilation
+#include <emu_c_utils/emu_c_utils.h>
+//#include <intrinsics.h>
 #endif
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Add.hpp
@@ -55,7 +55,9 @@
 #endif
 
 #if defined(KOKKOS_ENABLE_EMU)
-#include <intrinsics.h>
+//Replace specific Emu headers with the tools header to allow x86 compilation
+#include <emu_c_utils/emu_c_utils.h>
+//#include <intrinsics.h>
 #endif
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
+++ b/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
@@ -54,7 +54,9 @@
 #endif
 
 #if defined(KOKKOS_ENABLE_EMU)
-#include <intrinsics.h>
+//Replace specific Emu headers with the tools header to allow x86 compilation
+#include <emu_c_utils/emu_c_utils.h>
+//#include <intrinsics.h>
 #endif
 
 namespace Kokkos {

--- a/core/src/impl/Kokkos_SharedAlloc.cpp
+++ b/core/src/impl/Kokkos_SharedAlloc.cpp
@@ -44,9 +44,11 @@
 #include <Kokkos_Core.hpp>
 
 #if defined(KOKKOS_ENABLE_EMU)
-   #include <memoryweb.h>
-   #include <repl.h>
-   #include <pmanip.h>   
+//Replace specific Emu headers with the tools header to allow x86 compilation
+#include <emu_c_utils/emu_c_utils.h>
+   //#include <memoryweb.h>
+   //#include <repl.h>
+   //#include <pmanip.h>   
 #endif
 
 namespace Kokkos {
@@ -89,10 +91,10 @@ void init_locks( int i ) {
  */
 void initialize_memory_locks() {
 	int nCnt = NODELETS();
-	long * ll_ = mw_malloc1dlong(nCnt);
-	long * clp_ = mw_malloc1dlong(nCnt);
-	long * lh_ = mw_malloc1dlong(nCnt);
-	long * llock_ = mw_malloc1dlong(nCnt);
+	long * ll_ = (long*)mw_malloc1dlong(nCnt);
+	long * clp_ = (long*)mw_malloc1dlong(nCnt);
+	long * lh_ = (long*)mw_malloc1dlong(nCnt);
+	long * llock_ = (long*)mw_malloc1dlong(nCnt);
 	long ** lol_ = (long**)mw_malloc2d(nCnt, KOKKOS_MEMORY_LOCK_LEN * sizeof(AddrLock));
 	
 	mw_replicated_init( &list_lock, (long)ll_ );
@@ -126,7 +128,7 @@ bool free_lock(int i) {
 // if its in the list, it's locked...
 bool lock_addr( unsigned long ad ) {
   unsigned long addr = ad;
-  int nNode = mw_ptrtonodelet( addr );  
+  int nNode = mw_ptrtonodelet( (void*)addr );  
   bool bFound = true;
   if ( get_lock(nNode, addr) ) {	 
 	 bFound = false;
@@ -212,7 +214,7 @@ void free_node( int i, AddrLock * pWork) {
 // take it out of the list to free the lock...
 void unlock_addr( unsigned long ad ) {
   unsigned long addr = ad;
-  int nNode = mw_ptrtonodelet( addr );  
+  int nNode = mw_ptrtonodelet( (void*)addr );  
   bool bLock = get_lock(nNode, addr);  // this has to get a lock...we will wait.
   while( !bLock  )  {
 	  emu_sleep(10);

--- a/core/src/impl/Kokkos_TaskNode.hpp
+++ b/core/src/impl/Kokkos_TaskNode.hpp
@@ -582,7 +582,7 @@ public:
 	if (m_apply != nullptr) {
        (*m_apply)(this, &member);
     } else {
-		printf("run apply is nullptr %d \n", mw_ptrtonodelet(this));
+		printf("run apply is nullptr %lu \n", mw_ptrtonodelet(this));
 		KOKKOS_ASSERT(0 && "run apply is nullptr")
 	}
   }

--- a/core/unit_test/Makefile
+++ b/core/unit_test/Makefile
@@ -25,10 +25,18 @@ default: build_all
 ifeq (,$(findstring Emu,$(KOKKOS_DEVICES)))
   KOKKOS_ENABLE_EMU=1
 endif
+
+#Set the X86 flag explicitly to try and compile Emu code with memoryweb_x86 and gc
+KOKKOS_EMU_X86=1
+
 ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
   CXX = $(KOKKOS_PATH)/bin/nvcc_wrapper
 else ifeq ($(KOKKOS_ENABLE_EMU), 1)
-  CXX = emu-cc
+  ifeq ($(KOKKOS_EMU_X86), 1)
+    CXX = g++-7
+  else
+    CXX = emu-cc
+  endif
 else
   CXX = g++
 endif
@@ -39,14 +47,22 @@ LDFLAGS ?=
 ifneq ($(KOKKOS_ENABLE_EMU), 1)
 override LDFLAGS += -lpthread
 else
-override LDFLAGS += -lemu_c_utils
+  ifeq ($(KOKKOS_EMU_X86), 1)
+    override LDFLAGS += -rdynamic -lcilkrts /usr/local/emu/x86/lib/libemu_c_utils.a
+  else
+    override LDFLAGS += -lemu_c_utils
+  endif
 endif
 
 include $(KOKKOS_PATH)/Makefile.kokkos
 
 KOKKOS_CXXFLAGS += -I${KOKKOS_PATH}/core/unit_test -I${KOKKOS_PATH}/tpls/mdspan/include
 ifeq ($(KOKKOS_ENABLE_EMU), 1)
-KOKKOS_CXXFLAGS += -I${KOKKOS_PATH}/core/unit_test/emu-test
+  KOKKOS_CXXFLAGS += -I${KOKKOS_PATH}/core/unit_test/emu-test
+  ifeq ($(KOKKOS_EMU_X86), 1)
+  #Added flags needed for GCC compile
+  KOKKOS_CXXFLAGS += -fcilkplus -Wno-uninitialized -I/usr/local/emu/x86/include
+  endif
 else
 KOKKOS_CXXFLAGS += -I$(GTEST_PATH)
 endif
@@ -147,13 +163,19 @@ endif
 
 ifeq ($(KOKKOS_INTERNAL_USE_CILKPLUS), 1)
    ifeq ($(KOKKOS_ENABLE_EMU), 1)
-        OBJ_CILKPLUS = UnitTestEmuMain.o emu-test.o streamimport.o
+        #JY - testing GCC compile on 2/10/20
+      OBJ_CILKPLUS = UnitTestEmuMain.o emu-test.o
+    ifeq ($(KOKKOS_EMU_X86), 0)
+      OBJ_CILKPLUS = UnitTestEmuMain.o emu-test.o streamimport.o
+    endif
    else
         OBJ_CILKPLUS = UnitTestMainInit.o gtest-all.o
    endif
 #        OBJ_CILKPLUS += TestCilkPlus_Init.o
 #        OBJ_CILKPLUS += TestCilkPlus_SharedAlloc.o
+    ifeq ($(KOKKOS_EMU_X86), 0)
         OBJ_CILKPLUS += TestCilkPlus_RangePolicy.o
+    endif
 ##        OBJ_CILKPLUS += TestCilkPlus_ViewAPI_b.o
 ##        OBJ_CILKPLUS += TestCilkPlus_ViewMapping_a.o TestCilkPlus_ViewMapping_b.o TestCilkPlus_ViewMapping_subview.o
 ##        OBJ_CILKPLUS += TestCilkPlus_ViewOfClass.o
@@ -168,7 +190,10 @@ ifeq ($(KOKKOS_INTERNAL_USE_CILKPLUS), 1)
 ##        OBJ_CILKPLUS += TestCilkPlus_AtomicOperations.o
 ##        OBJ_CILKPLUS += TestCilkPlus_AtomicViews.o
 ##        OBJ_CILKPLUS += TestCilkPlus_Atomics.o
-        OBJ_CILKPLUS += TestViewMemoryTraits.o        
+        
+    ifeq ($(KOKKOS_EMU_X86), 0)
+	OBJ_CILKPLUS += TestViewMemoryTraits.o
+    endif       
 ##        OBJ_CILKPLUS += TestCilkPlus_Team.o TestCilkPlus_TeamScratch.o
 ##        OBJ_CILKPLUS += TestCilkPlus_TeamReductionScan.o
 ##        OBJ_CILKPLUS += TestCilkPlus_Other.o

--- a/core/unit_test/emu-test/UnitTestEmuMain.cpp
+++ b/core/unit_test/emu-test/UnitTestEmuMain.cpp
@@ -45,9 +45,11 @@
 #include <cstdlib>
 #include <cstring>
 #include <sys/time.h>
-#include <streamimport.h>
+//#include <streamimport.h>
 #include <emu-test.h>
-#include <memoryweb.h>
+//Replace specific Emu headers with the tools header to allow x86 compilation
+#include <emu_c_utils/emu_c_utils.h>
+//#include <memoryweb.h>
 
 #include <Kokkos_Core.hpp>
 

--- a/core/unit_test/emu-test/emu-test.cpp
+++ b/core/unit_test/emu-test/emu-test.cpp
@@ -1,6 +1,8 @@
 #define INCLUDE_CLASS
 #include <emu-test.h>
-#include <memoryweb/intrinsics.h>
+//Replace specific Emu headers with the tools header to allow x86 compilation
+#include <emu_c_utils/emu_c_utils.h>
+//#include <memoryweb/intrinsics.h>
 
 #include <time.h>
 

--- a/core/unit_test/emu-test/emu-test.h
+++ b/core/unit_test/emu-test/emu-test.h
@@ -1,6 +1,6 @@
 #ifndef __EMU_TEST_INTERFACE_
 #define __EMU_TEST_INTERFACE_
-#include <streamimport.h>
+//#include <streamimport.h>
 #include <string>
 #include <vector>
 #include <math.h>


### PR DESCRIPTION
These commits fix some includes for Emu low-level files like pmanip, intrinsics, and other files that can be satisfied using memoryweb.h and emu_c_utils, which allows for compiling with emu-cc or gcc. Some casting warnings that caused errors with gcc-7 were also fixed. 

It also includes some minor modifications to the Makefile to allow for compiling an "x86 emu" libkokkos.a that can then be linked with Emu programs to test the Kokkos Emu backend on x86 platforms. Compilation was tested with gcc-7, which still includes support for CilkPlus.